### PR TITLE
Add explicit license to the project. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,12 @@
 	<packaging>hpi</packaging>
 	<url>http://wiki.jenkins-ci.org/display/JENKINS/Build+Environment+Plugin</url>
 	
+    <licenses>
+        <license>
+            <name>MIT license</name>
+            <comments>All source code is under the MIT license.</comments>
+        </license>
+    </licenses>
 	<!-- get every artifact through repo.jenkins-ci.org, which proxies all the 
 		artifacts that we need -->
 	<repositories>


### PR DESCRIPTION
Some users may be put off using a plugin that has no license directly associated with it.